### PR TITLE
Create ES instance before install

### DIFF
--- a/modules/chassis-elasticsearch/manifests/init.pp
+++ b/modules/chassis-elasticsearch/manifests/init.pp
@@ -66,12 +66,12 @@ class chassis-elasticsearch(
     # Ensure a dummy index is missing; this ensures the ES connection is
     # running before we try installing.
     elasticsearch::index { 'chassis-validate-es-connection':
-      ensure => 'absent',
+      ensure  => 'absent',
       require => [
         Elasticsearch::Instance[ $options[instances] ],
         Elasticsearch::Plugin[ $options[plugins] ],
       ],
-      before => Chassis::Wp[ $config['hosts'][0] ],
+      before  => Chassis::Wp[ $config['hosts'][0] ],
     }
   }
 }

--- a/modules/chassis-elasticsearch/manifests/init.pp
+++ b/modules/chassis-elasticsearch/manifests/init.pp
@@ -24,7 +24,7 @@ class chassis-elasticsearch(
       ],
       'host'         => '0.0.0.0',
       'port'         => 9200,
-      'timeout'      => 10,
+      'timeout'      => 30,
       'instances'    => [
         'es'
       ],

--- a/modules/chassis-elasticsearch/manifests/init.pp
+++ b/modules/chassis-elasticsearch/manifests/init.pp
@@ -56,13 +56,15 @@ class chassis-elasticsearch(
       config => {
         'network.host' => '0.0.0.0'
       },
-      before => Class['chassis'],
+      require => Class['elasticsearch'],
+      before => Chassis::Wp[ $config['hosts'][0] ],
     }
 
     # Install plugins
     elasticsearch::plugin { $options[plugins]:
       instances => $options[instances],
-      before => Class['chassis'],
+      require => Class['elasticsearch'],
+      before => Chassis::Wp[ $config['hosts'][0] ],
     }
   }
 }

--- a/modules/chassis-elasticsearch/manifests/init.pp
+++ b/modules/chassis-elasticsearch/manifests/init.pp
@@ -55,12 +55,14 @@ class chassis-elasticsearch(
     elasticsearch::instance { $options[instances]:
       config => {
         'network.host' => '0.0.0.0'
-      }
+      },
+      before => Class['chassis'],
     }
 
     # Install plugins
     elasticsearch::plugin { $options[plugins]:
       instances => $options[instances],
+      before => Class['chassis'],
     }
   }
 }

--- a/modules/chassis-elasticsearch/manifests/init.pp
+++ b/modules/chassis-elasticsearch/manifests/init.pp
@@ -56,14 +56,21 @@ class chassis-elasticsearch(
       config => {
         'network.host' => '0.0.0.0'
       },
-      require => Class['elasticsearch'],
-      before => Chassis::Wp[ $config['hosts'][0] ],
     }
 
     # Install plugins
     elasticsearch::plugin { $options[plugins]:
       instances => $options[instances],
-      require => Class['elasticsearch'],
+    }
+
+    # Ensure a dummy index is missing; this ensures the ES connection is
+    # running before we try installing.
+    elasticsearch::index { 'chassis-validate-es-connection':
+      ensure => 'absent',
+      require => [
+        Elasticsearch::Instance[ $options[instances] ],
+        Elasticsearch::Plugin[ $options[plugins] ],
+      ],
       before => Chassis::Wp[ $config['hosts'][0] ],
     }
   }


### PR DESCRIPTION
Ensures the ES instance is created before WP is installed.

I'm using a hack of ensuring a non-existent index doesn't exist, which forces it to wait until the ES API is launched, with no other effects. I had to increase the timeout here up to 30, as the first launch was taking ~12s.