### PR TITLE
Update elasticsearch module to fix breaking issue with v6.x and symlinks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/elasticsearch"]
 	path = modules/elasticsearch
-	url = https://github.com/elastic/puppet-elasticsearch.git
+	url = https://github.com/humanmade/puppet-elasticsearch.git
 [submodule "modules/archive"]
 	path = modules/archive
 	url = https://github.com/voxpupuli/puppet-archive.git


### PR DESCRIPTION
Using Elasticpress 6.3.1, the provision fails because of the symlinked scripts folder, which seems to not be supported by Elastic ( removed in repo version 6.x, but the fix has not been backported to 5.x ).

Ref: https://github.com/elastic/puppet-elasticsearch/pull/1052