### PR TITLE
Add ruby function to merge JVM options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,33 @@ elasticsearch:
   timeout: 10
   instances:
     - 'es'
+  # You may want to increase the memory limit here if you are indexing images & files.
+  # Note you may also need to increase the memory limits for the VM and PHP also.
+  # Value is in Megabytes.
+  memory: 256
+  # You can override the default JVM options here as an array. For more information
+  # see the docs at https://www.elastic.co/guide/en/elasticsearch/reference/master/jvm-options.html
   jvm_options:
-    # You may want to increase the memory limits here if you are indexing images & files.
-    # Note you may also need to increase the memory limits for the VM and PHP also.
+    # Alternative way to configure the memory heap size settings at a more granular level.
     - '-Xms256m'
     - '-Xmx256m'
 ```
 
-#### Debugging Elasticsearch
+### A note on memory usage
+
+If you do increase the memory available to Elasticsearch you should generally ensure the VM itself has double that amount of memory to ensure all extensions and services run smoothly.
+
+The below example gives Elasticsearch 1Gig of memory and increases the VM memory to 2Gig.
+
+```yaml
+elasticsearch:
+  memory: 1024
+
+virtualbox:
+  memory: 2048
+```
+
+### Debugging Elasticsearch
 
 If you're having trouble with Elasticsearch there are a few common commands you can run inside Vagrant.
 

--- a/modules/chassis_elasticsearch/lib/puppet/functions/merge_jvm_options.rb
+++ b/modules/chassis_elasticsearch/lib/puppet/functions/merge_jvm_options.rb
@@ -1,0 +1,67 @@
+# @summary
+#
+#   Merges a JVM options with a defaults array, removing any duplicates from the defaults.
+#
+# Parameter: JVM options array to merge with defaults.
+# Parameter: Default JVM options array.
+#
+Puppet::Functions.create_function(:merge_jvm_options) do
+	# @param options The options array to merge with the default.
+	# @param defaults The default options array to merge against.
+	#
+	# @return array of merged options.
+	#
+	dispatch :merge? do
+		param 'Array', :options
+		param 'Array', :defaults
+		return_type 'Array'
+	end
+
+	def merge?(options, defaults)
+		# Keys to match JVM option values
+		keys = [
+			'-Dfile.encoding',
+			'-Dio.netty.noKeySetOptimization',
+			'-Dio.netty.noUnsafe',
+			'-Dio.netty.recycler.maxCapacityPerThread',
+			'-Djava.awt.headless',
+			'-Djna.nosys',
+			'-Dlog4j.shutdownHookEnabled',
+			'-Dlog4j2.disable.jmx',
+			'AlwaysPreTouch',
+			'HeapDumpOnOutOfMemoryError',
+			'UseG1GC',
+			'OmitStackTraceInFastThrow',
+			'CMSInitiatingOccupancyFraction',
+			'-Xms',
+			'-Xmx',
+			'-Xss',
+			'server',
+			'InitiatingHeapOccupancyPercent',
+			'PrintGCApplicationStoppedTime',
+			'PrintGCDateStamps',
+			'PrintGCDetails',
+			'PrintTenuringDistribution',
+			'UseCMSInitiatingOccupancyOnly',
+			'UseConcMarkSweepGC',
+			'UseGCLogFileRotation',
+			'GCLogFileSize',
+			'NumberOfGCLogFiles',
+			'Xloggc'
+		]
+
+		# Collect corresponding keys from the options array
+		option_keys = options.reduce([]) do |carry, option|
+			option.match(/(#{keys.join('|')})/) { |m| carry << m[1] }
+			carry
+		end
+
+		# Remove matched option keys from the defaults array
+		trimmed_defaults = defaults.reduce([]) do |carry, default|
+			carry << default if default !~ /(#{option_keys.join('|')})/
+			carry
+		end
+
+		options + trimmed_defaults
+	end
+end

--- a/modules/chassis_elasticsearch/lib/puppet/functions/merge_jvm_options.rb
+++ b/modules/chassis_elasticsearch/lib/puppet/functions/merge_jvm_options.rb
@@ -58,7 +58,7 @@ Puppet::Functions.create_function(:merge_jvm_options) do
 
 		# Remove matched option keys from the defaults array
 		trimmed_defaults = defaults.reduce([]) do |carry, default|
-			carry << default if default !~ /(#{option_keys.join('|')})/
+			carry << default if option_keys.empty? or default !~ /(#{option_keys.join('|')})/
 			carry
 		end
 

--- a/modules/chassis_elasticsearch/manifests/init.pp
+++ b/modules/chassis_elasticsearch/manifests/init.pp
@@ -11,9 +11,6 @@ class chassis_elasticsearch(
     class { 'elasticsearch':
       ensure => 'absent'
     }
-    package { 'java-common':
-      ensure => absent
-    }
   } else {
     # Default settings for install
     $defaults = {


### PR DESCRIPTION
Fixes #22

Right now using `deep_merge` results in the JVM options array being overwritten completely. The default options added since updating this module to use elasticstack and Java 11 result in the service not being able to start depending on the version of Elasticsearch selected.

This ensures that the default JVM options are scoped to the Java versions they work with and that any overrides do not cause these safe defaults to be overwritten completely unless it is intentional.

The update is backwards compatible with installations that set the `-Xmx` and `-Xms` JVM options using the legacy method and adds a new simpler option `memory` that will set these options for you.