### PR TITLE
Add dictionary file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To reference files added to that location you can use a relative path with the `
     },
     "analyzer": {
       "default": {
-        "type": "custom"
+        "type": "custom",
         "filter": [
           "custom_stopwords"
         ],

--- a/README.md
+++ b/README.md
@@ -41,6 +41,36 @@ ELASTICSEARCH_PORT // defaults to 9200
 We recommend using the [Head Chrome Extension](https://chrome.google.com/webstore/detail/elasticsearch-head/ffmkiejjmecolpfloofpjologoblkegm/) for debugging queries and exploring
 your indexes.
 
+### Custom Dictionary Files
+
+Elasticsearch supports using text files for providing stopwords, synonyms and if using the `analysis-kuromoji` plugin a custom user dictionary file for tokenisation.
+
+This extension ensures there is a directory at `/usr/share/elasticsearch/config` that is writable by the web server.
+
+To reference files added to that location you can use a relative path with the `config/` prefix. For example you could create an analyser using a custom stopwords file in the following way:
+
+```json
+{
+  "analysis": {
+    "filter": {
+      "custom_stopwords": {
+        "type": "stop",
+        "stopwords_path": "config/stopwords.txt"
+      }
+    },
+    "analyzer": {
+      "default": {
+        "type": "custom"
+        "filter": [
+          "custom_stopwords"
+        ],
+        "tokenizer": "standard"
+      }
+    }
+  }
+}
+```
+
 ## Configuration
 
 Chassis ElasticSearch provides some default options you can override from your

--- a/modules/chassis_elasticsearch/manifests/init.pp
+++ b/modules/chassis_elasticsearch/manifests/init.pp
@@ -105,16 +105,19 @@ class chassis_elasticsearch(
 
     # Create shared config directory and give write permissions to web server.
     $package_symlinks = $options[instances].map |$index, $value| { "/etc/elasticsearch/${value}/config" }
+
     file { '/usr/share/elasticsearch/config':
       ensure  => directory,
       owner => 'elasticsearch',
       group => 'www-data',
       mode => '0777',
       require => Elasticsearch::Instance[ $options[instances] ],
-    } ~>
+    }
+
     file { $package_symlinks:
       ensure => link,
-      target => '/usr/share/elasticsearch/config'
+      target => '/usr/share/elasticsearch/config',
+      require => File['/usr/share/elasticsearch/config']
     }
   }
 }

--- a/modules/chassis_elasticsearch/manifests/init.pp
+++ b/modules/chassis_elasticsearch/manifests/init.pp
@@ -108,15 +108,15 @@ class chassis_elasticsearch(
 
     file { '/usr/share/elasticsearch/config':
       ensure  => directory,
-      owner => 'elasticsearch',
-      group => 'www-data',
-      mode => '0777',
+      owner   => 'elasticsearch',
+      group   => 'www-data',
+      mode    => '0777',
       require => Elasticsearch::Instance[ $options[instances] ],
     }
 
     file { $package_symlinks:
-      ensure => link,
-      target => '/usr/share/elasticsearch/config',
+      ensure  => link,
+      target  => '/usr/share/elasticsearch/config',
       require => File['/usr/share/elasticsearch/config']
     }
   }

--- a/modules/chassis_elasticsearch/manifests/init.pp
+++ b/modules/chassis_elasticsearch/manifests/init.pp
@@ -102,5 +102,19 @@ class chassis_elasticsearch(
       ],
       before  => Chassis::Wp[ $config['hosts'][0] ],
     }
+
+    # Create shared config directory and give write permissions to web server.
+    $package_symlinks = $options[instances].map |$index, $value| { "/etc/elasticsearch/${value}/config" }
+    file { '/usr/share/elasticsearch/config':
+      ensure  => directory,
+      owner => 'elasticsearch',
+      group => 'www-data',
+      mode => '0777',
+      require => Elasticsearch::Instance[ $options[instances] ],
+    } ~>
+    file { $package_symlinks:
+      ensure => link,
+      target => '/usr/share/elasticsearch/config'
+    }
   }
 }


### PR DESCRIPTION
This update provides a single location that is writable by the web server and symlinked to the Elasticsearch instance config file directories.

This allows adding custom files for stopwords that can be referenced in analysers via a path like `config/stopwords.txt` and managing those files via PHP.